### PR TITLE
Travis: Fix dep issues

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -52,12 +52,12 @@
   version = "v2.1.1"
 
 [[projects]]
-  digest = "1:ce36c38655294f7a1c19b96c01ef0e94a843773e289de557c754dc3756c514a4"
+  digest = "1:cb1eb706e2ebae50593fb3614afbdd03c9465ee7653f67c0cbc4dd050889d0cb"
   name = "github.com/TerrexTech/uuuid"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a29ab526ee6513a1fd0195b41a921f305298b1c2"
-  version = "v1.0.0"
+  revision = "f8dab568898928167bc274d98c3e6cb6370e6458"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:526d64d0a3ac6c24875724a9355895be56a21f89a5d3ab5ba88d91244269a7d8"
@@ -259,11 +259,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:01a910c4664c362dbf8e9eb3a64944996ed36874d07c5a95c08175dd5ff7a648"
+  digest = "1:4c18b929ff2f30ebf16c43fd9e0755fad03b290af199c5bcd82dde4c80cf8781"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "c01370cb5c9b7812800ec97eb5692a14fb8d577c"
+  revision = "90868a75fefd03942536221d7c0e2f84ec62a668"
 
 [[projects]]
   digest = "1:aa4d6967a3237f8367b6bf91503964a77183ecf696f1273e8ad3551bb4412b5f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,11 +42,15 @@
 
 [[constraint]]
   name = "github.com/TerrexTech/go-eventstore-models"
-  version = "2.0.1"
+  version = "2.1.1"
 
 [[constraint]]
   name = "github.com/TerrexTech/go-kafkautils"
   version = "2.1.1"
+
+[[constraint]]
+  name = "github.com/TerrexTech/uuuid"
+  version = "1.0.1"
 
 [[constraint]]
   branch = "master"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,11 +24,11 @@ end
 
 Vagrant.configure(2) do |config|
   config.vm.define :queryvm do |queryvm|
-    queryvm.vm.hostname = "persistence"
+    queryvm.vm.hostname = "query"
     queryvm.vm.box = "bento/ubuntu-16.04"
 
     queryvm.vm.provider :virtualbox do |vb|
-      vb.name = "persistence-vm"
+      vb.name = "query-vm"
       vb.gui = false
       vb.memory = "2024"
       vb.cpus = 2

--- a/ioutil/dbutil.go
+++ b/ioutil/dbutil.go
@@ -33,7 +33,7 @@ func (dbu *DBUtil) GetAggMetaVersion(
 	eventStoreQuery *model.EventStoreQuery,
 ) (int64, error) {
 	aggID := eventStoreQuery.AggregateID
-	if aggID == 1 {
+	if aggID == 0 {
 		return -1, errors.New("AggregateID not specified")
 	}
 

--- a/ioutil/queryutil.go
+++ b/ioutil/queryutil.go
@@ -30,6 +30,7 @@ func (qu *QueryUtil) QueryHandler(
 	eventMetaPartnKey int8,
 	query *model.EventStoreQuery,
 ) (*[]model.Event, error) {
+	log.Println(query)
 	// Get Aggregate Meta-Version
 	aggMetaVersion, err := qu.DBUtil.GetAggMetaVersion(eventMetaPartnKey, query)
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/TerrexTech/uuuid"
 	"encoding/json"
 	"log"
 	"os"
@@ -166,5 +165,5 @@ func processQuery(
 		log.Println(err)
 		return
 	}
-	queryUtil.BatchProduce(query.CorrelationID uuuid.UUID, query.AggregateID, events)
+	queryUtil.BatchProduce(query.CorrelationID, query.AggregateID, events)
 }

--- a/run_test.sh
+++ b/run_test.sh
@@ -47,9 +47,14 @@ done
 go test -v ./...
 
 docker-compose up -d --build go-eventstore-query
+rc=$?
+if [[ $rc != 0 ]]
+  then exit $rc
+fi
 
 echo "Waiting for Go-API Sessions to initialize"
 sleep 5
 
 # Run Kafka tests
 docker-compose up --build go-eventstore-query-test
+exit $?


### PR DESCRIPTION
Also fixes CI test-script so that it returns non-zero return-code if any error occurs. Earlier, the script used to exit with rc 0 even if there was an error.